### PR TITLE
style: Set rotate example figures

### DIFF
--- a/index.html
+++ b/index.html
@@ -323,14 +323,18 @@ My CSS Cheat Sheet for learning CSS - Transitions and Transforms
         <div class="subsection_box">
           <figure id="fig_no_rotate">
             <figcaption>What we start with...</figcaption>
-            <div></div>
+            <div class="example_fig_box">
+              <div class="example_fig"></div>
+            </div>
           </figure>
         </div>
         <!--end of subsection_box - norotate-->
         <div class="subsection_box">
           <figure id="fig_rotate">
             <figcaption>rotate...</figcaption>
-            <div></div>
+            <div class="example_fig_box">
+              <div class="example_fig rotate"></div>
+            </div>
           </figure>
           <div class="code_snippet">
             <code>
@@ -345,7 +349,9 @@ My CSS Cheat Sheet for learning CSS - Transitions and Transforms
         <div class="subsection_box">
           <figure id="fig_rotate_x">
             <figcaption>rotate...X</figcaption>
-            <div></div>
+            <div class="example_fig_box">
+              <div class="example_fig rotatex"></div>
+            </div>
           </figure>
           <div class="code_snippet">
             <code>
@@ -360,7 +366,9 @@ My CSS Cheat Sheet for learning CSS - Transitions and Transforms
         <div class="subsection_box">
           <figure id="fig_rotate_y">
             <figcaption>rotate...Y</figcaption>
-            <div></div>
+            <div class="example_fig_box">
+              <div class="example_fig rotatey"></div>
+            </div>
           </figure>
           <div class="code_snippet">
             <code>

--- a/styles/style.css
+++ b/styles/style.css
@@ -314,6 +314,19 @@ code example figures
 .translatexy {
   transform: translate(50px, 50px);
 }
+
+/*rotate examples*/
+.rotate {
+  transform: rotate(40deg);
+}
+
+.rotatex {
+  transform: rotateX(40deg);
+}
+
+.rotatey {
+  transform: rotateY(40deg);
+}
 /*=====
 Sidebar
 ======*/
@@ -472,6 +485,10 @@ Accessibility
   root {
     --col_dark: #1e1b18;
     --col_light: #fffaff;
+  }
+
+  img {
+    filter: brightness(0.8) saturate(1.25);
   }
 }
 


### PR DESCRIPTION
Styling set to show example of rotate, rotateX and rotateY subsections under transforms section